### PR TITLE
Adding TRACING_FORMAT environment variable

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2099,6 +2099,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-serde"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc6b213177105856957181934e4920de57730fc69bf42c37ee5bb664d406d9e1"
+dependencies = [
+ "serde",
+ "tracing-core",
+]
+
+[[package]]
 name = "tracing-subscriber"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2108,12 +2118,15 @@ dependencies = [
  "lazy_static",
  "matchers",
  "regex",
+ "serde",
+ "serde_json",
  "sharded-slab",
  "smallvec",
  "thread_local",
  "tracing",
  "tracing-core",
  "tracing-log",
+ "tracing-serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ opentelemetry = { version = "0.17", features = ["rt-tokio"] }
 opentelemetry-jaeger = { version = "0.16", features = ["rt-tokio", "collector_client", "reqwest_collector_client"] }
 tracing = "0.1"
 tracing-opentelemetry = "0.17"
-tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
 tracing-tree = "0.2"
 
 postgres = { optional = true, version = "0.19" }

--- a/src/tracing.rs
+++ b/src/tracing.rs
@@ -1,4 +1,8 @@
-use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt, EnvFilter, Registry};
+use std::fmt::Debug;
+use tracing_subscriber::fmt::Layer;
+use tracing_subscriber::layer::SubscriberExt;
+use tracing_subscriber::util::SubscriberInitExt;
+use tracing_subscriber::{EnvFilter, Registry};
 use tracing_tree::HierarchicalLayer;
 
 use crate::{EnvironmentConfig, Feature, Parser, Result};
@@ -13,9 +17,12 @@ pub struct TracingConfig {
 
     #[clap(env = "TRACING_LOG_LEVEL", default_value = "debug")]
     pub log_level: String,
+
+    #[clap(arg_enum, env = "TRACING_FORMAT", default_value = "pretty")]
+    pub format: TracingFormat,
 }
 
-#[derive(Debug, Clone)]
+#[derive(clap::Parser, Debug, Clone)]
 pub struct Tracing;
 
 impl Feature for Tracing {
@@ -26,17 +33,53 @@ impl Feature for Tracing {
             .with_collector_endpoint(&config.tracing.opentelemetry_endpoint)
             .with_service_name(module_path!())
             .install_batch(opentelemetry::runtime::Tokio)?;
-
         let telemetry = tracing_opentelemetry::layer().with_tracer(tracer);
+
+        // tracing_subscriber lib currently does not support dynamically adding layer to registry
+        // accordingly to some condition. this can be verified in the following issues:
+        // https://github.com/tokio-rs/tracing/issues/575
+        // https://github.com/tokio-rs/tracing/issues/1708
+        //
+        // but there is a workaround described here:
+        // https://github.com/tokio-rs/tracing/issues/894
+        //
+        // the workaround consists of passing a optional of Layer to every conditional layer,
+        // so if Some(layer) is passed, that layer is active, if None the layer is inactive.
+        let (layer_format_json, layer_format_pretty, layer_format_hierarchical) =
+            match config.tracing.format {
+                TracingFormat::None => (None, None, None),
+                TracingFormat::Json => (Some(Layer::default().json()), None, None),
+                TracingFormat::Pretty => (
+                    None,
+                    Some(
+                        Layer::default()
+                            .pretty()
+                            .with_thread_ids(true)
+                            .with_thread_names(true)
+                            .with_target(true)
+                            .with_file(false)
+                            .with_line_number(false)
+                            .with_ansi(!config.core.no_color)
+                    ),
+                    None,
+                ),
+                TracingFormat::Hierarchical => (
+                    None,
+                    None,
+                    Some(
+                        HierarchicalLayer::new(2)
+                            .with_targets(true)
+                            .with_bracketed_fields(true)
+                            .with_ansi(!config.core.no_color),
+                    ),
+                ),
+            };
 
         Registry::default()
             .with(EnvFilter::from_default_env())
-            .with(
-                HierarchicalLayer::new(2)
-                    .with_targets(true)
-                    .with_bracketed_fields(true)
-                    .with_ansi(config.core.no_color),
-            )
+            .with(layer_format_json)
+            .with(layer_format_pretty)
+            .with(layer_format_hierarchical)
             .with(telemetry)
             .init();
 
@@ -51,4 +94,12 @@ impl Drop for Tracing {
         tracing::debug!("stopping tracer");
         opentelemetry::global::shutdown_tracer_provider();
     }
+}
+
+#[derive(clap::ArgEnum, Clone, Debug)]
+pub enum TracingFormat {
+    None,
+    Hierarchical,
+    Pretty,
+    Json,
 }


### PR DESCRIPTION
The TRACING_FORMAT allows the client of this library to choose how to format the tracing outputs.

4 formats are supported.
* None
* Pretty
* Hierarchical
* Json