### PR TITLE
Enable sqlx/offline

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -534,6 +534,9 @@ name = "either"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90e5c1c8368803113bf0c9584fc495a58b86dc8a29edbf8fe877d21d9507e797"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "encoding_rs"
@@ -2370,9 +2373,12 @@ dependencies = [
  "dotenvy",
  "either",
  "heck",
+ "hex",
  "once_cell",
  "proc-macro2",
  "quote",
+ "serde",
+ "serde_json",
  "sha2",
  "sqlx-core",
  "sqlx-rt",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,7 +62,11 @@ postgres = [
     "sqlx/postgres",
     "sqlx/runtime-tokio-rustls",
     "sqlx/uuid",
-    "sqlx/time"
+    "sqlx/time",
+    "sqlx/offline"
+]
+postgres-offline = [
+    "sqlx/offline"
 ]
 redis = [
     "bb8-redis"


### PR DESCRIPTION
SQLx offline without this only works incidentally (because of version mismatches), so this exposes it as a feature.