### PR TITLE
feat: export all number types from ethereum

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,7 +16,7 @@ pub use crate::trace::{
 
 pub use async_trait::async_trait;
 pub use clap::{self, Args, Parser};
-pub use ethereum_types::{H256, U256};
+pub use ethereum_types::{H128, H160, H256, H264, H32, H512, H520, H64, U128, U256, U512, U64};
 pub use eyre::Result;
 pub use futures_util::StreamExt;
 pub use quickcheck::Arbitrary;


### PR DESCRIPTION
This should reduce one direct dependency on our other projects.