### PR TITLE
Fix jeager collector

### DIFF
--- a/src/trace.rs
+++ b/src/trace.rs
@@ -148,6 +148,7 @@ impl Feature for Tracing {
                 .with_endpoint(&config.tracing.opentelemetry_endpoint)
                 .with_service_name(service_name)
                 .with_trace_config(trace::config().with_sampler(sampler))
+                .with_reqwest()
                 .install_batch(opentelemetry::runtime::Tokio)?;
 
             Some(

--- a/src/trace.rs
+++ b/src/trace.rs
@@ -144,7 +144,7 @@ impl Feature for Tracing {
                 None => Sampler::AlwaysOn,
             };
 
-            let tracer = opentelemetry_jaeger::new_agent_pipeline()
+            let tracer = opentelemetry_jaeger::new_collector_pipeline()
                 .with_endpoint(&config.tracing.opentelemetry_endpoint)
                 .with_service_name(service_name)
                 .with_trace_config(trace::config().with_sampler(sampler))


### PR DESCRIPTION
Jeager collector is expected to be used with an URL. Since version 0.17, `opentelemetry-jeager` [split the agent and collector pipelines](https://github.com/open-telemetry/opentelemetry-rust/pull/748). 

`new_agent_pipeline` expects a `SocketAddr` as `endpoint`, failing when is provided an url. So, we need to update the function as well.