### PR TITLE
feat: Redis: use MultiplexedConnection instead of simple Connection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -289,9 +289,9 @@ dependencies = [
 
 [[package]]
 name = "bb8-redis"
-version = "0.13.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "688ba412f8e9c4a7e131774a94bf5a95df12618d143981b97d2aaf0776815533"
+checksum = "cd456361ba8e4e7f5fe58e1697ce078a149c85ebce13bf9c6b483d3f566fc9c3"
 dependencies = [
  "async-trait",
  "bb8",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,7 +55,7 @@ sqlx = { optional = true, version = "0.6" }
 postgres = { optional = true, version = "0.19" }
 
 # redis
-bb8-redis = { optional = true, version = "0.13" }
+bb8-redis = { optional = true, version = "0.13.1" }
 
 # streaming
 rdkafka = { version = "0.30.0", features = ["cmake_build", "ssl"], optional = true }

--- a/src/redis.rs
+++ b/src/redis.rs
@@ -2,7 +2,7 @@ use std::ops::Deref;
 
 use crate::*;
 
-use bb8_redis::{bb8::Pool, RedisConnectionManager};
+use bb8_redis::{bb8::Pool, RedisMultiplexedConnectionManager};
 
 #[derive(Debug, Clone, Parser)]
 pub struct RedisConfig {
@@ -12,13 +12,13 @@ pub struct RedisConfig {
 
 #[derive(Debug, Clone)]
 pub struct Redis {
-    pool: Pool<RedisConnectionManager>,
+    pool: Pool<RedisMultiplexedConnectionManager>,
 }
 
 #[async_trait]
 impl Feature for Redis {
     async fn init(_service_name: &str, config: &EnvironmentConfig) -> Result<Self> {
-        let manager = RedisConnectionManager::new(config.redis.url.0.clone())?;
+        let manager = RedisMultiplexedConnectionManager::new(config.redis.url.0.clone())?;
         let connection_pool = Pool::builder().build(manager).await?;
 
         Ok(Self {
@@ -28,7 +28,7 @@ impl Feature for Redis {
 }
 
 impl Deref for Redis {
-    type Target = Pool<RedisConnectionManager>;
+    type Target = Pool<RedisMultiplexedConnectionManager>;
 
     fn deref(&self) -> &Self::Target {
         &self.pool


### PR DESCRIPTION
I propose using `bb8_redis::RedisMultiplexedConnectionManager` instead of `bb8_redis::RedisConnectionManager`. The former uses a [MultiplexedConnection](https://docs.rs/redis/latest/redis/aio/struct.MultiplexedConnection.html) under the hood, instead of a simple [Connection](https://docs.rs/redis/latest/redis/aio/struct.Connection.html).