### PR TITLE
Bump rustix version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2242,9 +2242,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.37.19"
+version = "0.37.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acf8729d8542766f1b2cf77eb034d52f40d375bb8b615d0b147089946e16613d"
+checksum = "fea8ca367a3a01fe35e6943c400addf443c0f57670e6ec51196f71a4b8762dd2"
 dependencies = [
  "bitflags 1.3.2",
  "errno",


### PR DESCRIPTION
Fixes https://github.com/cloudwalk/balthazar/security/dependabot/21